### PR TITLE
Prevent multiple values for keyword argument 'audience' in jwt.decode()

### DIFF
--- a/src/keycloak/openid_connect.py
+++ b/src/keycloak/openid_connect.py
@@ -92,9 +92,11 @@ class KeycloakOpenidConnect(WellKnownMixin):
         :raises jose.exceptions.JWTClaimsError: If any claim is invalid in any
             way.
         """
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k != 'audience'}
         return jwt.decode(token, key,
                           audience=kwargs.get('audience') or self._client_id,
-                          algorithms=algorithms or ['RS256'], **kwargs)
+                          algorithms=algorithms or ['RS256'],
+                          **filtered_kwargs)
 
     def logout(self, refresh_token):
         """

--- a/src/keycloak/openid_connect.py
+++ b/src/keycloak/openid_connect.py
@@ -92,11 +92,9 @@ class KeycloakOpenidConnect(WellKnownMixin):
         :raises jose.exceptions.JWTClaimsError: If any claim is invalid in any
             way.
         """
-        filtered_kwargs = {k: v for k, v in kwargs.items() if k != 'audience'}
         return jwt.decode(token, key,
-                          audience=kwargs.get('audience') or self._client_id,
-                          algorithms=algorithms or ['RS256'],
-                          **filtered_kwargs)
+                          audience=kwargs.pop('audience', None) or self._client_id,
+                          algorithms=algorithms or ['RS256'], **kwargs)
 
     def logout(self, refresh_token):
         """


### PR DESCRIPTION
When the `'audience'` keyword is present in the call to `decode_token()`, it is passed twice to `jwt.decode()`, causing the error: `TypeError: decode() got multiple values for keyword argument 'audience'`. This is fixed trivially by filtering `kwargs` to exclude `'audience'`.