### PR TITLE
Fix "deploy-pypi"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ bump-minor:
 	bumpversion minor
 
 deploy-pypi: clear
-	python setup.py sdist bdist_wheel
+	python3 -c "import sys; sys.version_info >= (3, 5, 3) or sys.stdout.write('Python version must be greatest then 3.5.2\n') or exit(1)"
+	python3 setup.py sdist bdist_wheel
 	twine upload dist/*
 
 clear:


### PR DESCRIPTION
Resolve #11
Package must be rebuilded with `python >= 3.5.3` and redeployed to PyPi