### PR TITLE
Allow to query registered users

### DIFF
--- a/src/keycloak/admin/users.py
+++ b/src/keycloak/admin/users.py
@@ -53,3 +53,45 @@ class Users(KeycloakAdminBase):
             ),
             data=json.dumps(payload)
         )
+
+    def all(self):
+        """
+        Return all registered users
+
+        http://www.keycloak.org/docs-api/3.4/rest-api/index.html#_users_resource
+        """
+        return self._client.get(
+            url=self._client.get_full_url(
+                self.get_path('collection', realm=self._realm_name)
+            )
+        )
+
+    def by_id(self, user_id):
+        return User(realm_name=self._realm_name,
+                    user_id=user_id, client=self._client)
+
+
+class User(KeycloakAdminBase):
+    _paths = {
+        'single': '/auth/admin/realms/{realm}/users/{user_id}'
+    }
+
+    def __init__(self, realm_name, user_id, *args, **kwargs):
+        self._realm_name = realm_name
+        self._user_id = user_id
+
+        super(User, self).__init__(*args, **kwargs)
+
+    def get(self):
+        """
+        Return registered user with the given user id.
+
+        http://www.keycloak.org/docs-api/3.4/rest-api/index.html#_users_resource
+        """
+        return self._client.get(
+            url=self._client.get_full_url(
+                self.get_path(
+                    'single', realm=self._realm_name, user_id=self._user_id
+                )
+            )
+        )

--- a/tests/keycloak/admin/test_users.py
+++ b/tests/keycloak/admin/test_users.py
@@ -38,3 +38,29 @@ class KeycloakAdminUsersTestCase(TestCase):
                 'Content-Type': 'application/json'
             }
         )
+
+    def test_get_collection(self):
+        self.admin.realms.by_name('realm-name').users.all()
+        self.realm.client.get_full_url.assert_called_once_with(
+            '/auth/admin/realms/realm-name/users'
+        )
+        self.realm.client.get.assert_called_once_with(
+            url=self.realm.client.get_full_url.return_value,
+            headers={
+                'Authorization': 'Bearer some-token',
+                'Content-Type': 'application/json'
+            }
+        )
+
+    def test_get_single(self):
+        self.admin.realms.by_name('realm-name').users.by_id('an-id').get()
+        self.realm.client.get_full_url.assert_called_once_with(
+            '/auth/admin/realms/realm-name/users/an-id'
+        )
+        self.realm.client.get.assert_called_once_with(
+            url=self.realm.client.get_full_url.return_value,
+            headers={
+                'Authorization': 'Bearer some-token',
+                'Content-Type': 'application/json'
+            }
+        )


### PR DESCRIPTION
So far it is only possible to create new users. Now all users, as well as an individual user, can be queried as well.