### PR TITLE
Fix requests session response with context

### DIFF
--- a/src/keycloak/client.py
+++ b/src/keycloak/client.py
@@ -79,7 +79,7 @@ class KeycloakClient(object):
         return self.session.delete(url, headers=headers, **kwargs)
 
     def _handle_response(self, response):
-        with response:
+        with self:
             try:
                 response.raise_for_status()
             except HTTPError as err:


### PR DESCRIPTION
requests response has no \_\_enter__ method, with this client class \_\_enter__ and close method, here should be self