### PR TITLE
Rework entities

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,11 +4,13 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+pylint = "*"
 
 [packages]
 requests = "*"
 python-jose = "*"
 mock = "*"
+
 
 [requires]
 python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+requests = "*"
+python-jose = "*"
+mock = "*"
+
+[requires]
+python_version = "3.7"

--- a/src/keycloak/admin/__init__.py
+++ b/src/keycloak/admin/__init__.py
@@ -34,9 +34,7 @@ class KeycloakAdminEntity(KeycloakAdminBase):
 
     def _get(self):
         self._entity = self._client.get(
-            self._client.get_full_url(
-                self._url
-            )
+            self._client.get_full_url(self._url)
         )
 
     @property
@@ -47,9 +45,7 @@ class KeycloakAdminEntity(KeycloakAdminBase):
 
     @property
     def url(self):
-        return self._client.get_full_url(
-                self._url
-            )
+        return self._client.get_full_url(self._url)
 
     def update(self, **kwargs):
         """
@@ -60,9 +56,7 @@ class KeycloakAdminEntity(KeycloakAdminBase):
         :return: Response
         """
         resp = self._client.put(
-            url=self._client.get_full_url(
-                self._url
-            ),
+            url=self._client.get_full_url(self._url),
             data=json.dumps(kwargs, sort_keys=True)
         )
         self._get()
@@ -75,9 +69,7 @@ class KeycloakAdminEntity(KeycloakAdminBase):
         :return: Response
         """
         return self._client.delete(
-            self._client.get_full_url(
-                self._url
-            )
+            self._client.get_full_url(self._url)
         )
 
     def __getattr__(self, item):

--- a/src/keycloak/admin/__init__.py
+++ b/src/keycloak/admin/__init__.py
@@ -28,15 +28,14 @@ class KeycloakAdminEntity(KeycloakAdminBase):
 
     def __init__(self, client, url):
         super().__init__(client)
-        self._BASE = url
-        self._paths['formatted'] = self._BASE
+        self._url = url
         self._client = client
         self._entity = None
 
     def _get(self):
         self._entity = self._client.get(
             self._client.get_full_url(
-                self.get_path('formatted')
+                self._url
             )
         )
 
@@ -56,7 +55,7 @@ class KeycloakAdminEntity(KeycloakAdminBase):
         """
         resp = self._client.put(
             url=self._client.get_full_url(
-                self.get_path("formatted")
+                self._url
             ),
             data=json.dumps(kwargs, sort_keys=True)
         )
@@ -71,7 +70,7 @@ class KeycloakAdminEntity(KeycloakAdminBase):
         """
         return self._client.delete(
             self._client.get_full_url(
-                self.get_path("formatted")
+                self._url
             )
         )
 

--- a/src/keycloak/admin/__init__.py
+++ b/src/keycloak/admin/__init__.py
@@ -47,7 +47,7 @@ class KeycloakAdminEntity(KeycloakAdminBase):
 
     @property
     def url(self):
-        return self._url
+        return self.get_full_url(self._url)
 
     def update(self, **kwargs):
         """

--- a/src/keycloak/admin/__init__.py
+++ b/src/keycloak/admin/__init__.py
@@ -42,6 +42,8 @@ class KeycloakAdminEntity(KeycloakAdminBase):
 
     @property
     def entity(self):
+        if self._entity is None:
+            self._get()
         return self._entity
 
     def update(self, **kwargs):

--- a/src/keycloak/admin/__init__.py
+++ b/src/keycloak/admin/__init__.py
@@ -23,33 +23,6 @@ class KeycloakAdminBase(object):
         return self._paths[name].format(**kwargs)
 
 
-# class KeycloakAdminCollection(KeycloakAdminBase):
-#     _paths = {}
-#
-#     def __init__(self, client, element_cls, url):
-#         self._paths['collection'] = url
-#         self._element_cls = element_cls
-#         super().__init__(client)
-#
-#     def get(self, id):
-#         return self._element_cls(id=id, client=self._client)
-#
-#     def all(self):
-#         return self._client.get(
-#             self._client.get_full_url(
-#                 self.get_path('collection')
-#             )
-#         )
-#
-#     def create(self, **kwargs):
-#         self._client.post(
-#             self._client.get_full_url(
-#                 self.get_path("collection")
-#             ),
-#             json.dumps(payload)
-#         )
-#         return Realm(id=, client=self._client)
-
 class KeycloakAdminEntity(KeycloakAdminBase):
     _paths = {}
 
@@ -59,7 +32,6 @@ class KeycloakAdminEntity(KeycloakAdminBase):
         self._paths['formatted'] = self._BASE
         self._client = client
         self._entity = None
-        self._get()
 
     def _get(self):
         self._entity = self._client.get(
@@ -102,6 +74,8 @@ class KeycloakAdminEntity(KeycloakAdminBase):
         )
 
     def __getattr__(self, item):
+        if self._entity is None:
+            self._get()
         return self._entity[item]
 
 

--- a/src/keycloak/admin/__init__.py
+++ b/src/keycloak/admin/__init__.py
@@ -45,6 +45,10 @@ class KeycloakAdminEntity(KeycloakAdminBase):
             self._get()
         return self._entity
 
+    @property
+    def url(self):
+        return self._url
+
     def update(self, **kwargs):
         """
         Updates the given entity

--- a/src/keycloak/admin/__init__.py
+++ b/src/keycloak/admin/__init__.py
@@ -47,7 +47,9 @@ class KeycloakAdminEntity(KeycloakAdminBase):
 
     @property
     def url(self):
-        return self.get_full_url(self._url)
+        return self._client.get_full_url(
+                self._url
+            )
 
     def update(self, **kwargs):
         """

--- a/src/keycloak/admin/__init__.py
+++ b/src/keycloak/admin/__init__.py
@@ -1,3 +1,5 @@
+import json
+
 __all__ = (
     'KeycloakAdmin',
     'KeycloakAdminBase',
@@ -19,6 +21,88 @@ class KeycloakAdminBase(object):
             raise NotImplementedError()
 
         return self._paths[name].format(**kwargs)
+
+
+# class KeycloakAdminCollection(KeycloakAdminBase):
+#     _paths = {}
+#
+#     def __init__(self, client, element_cls, url):
+#         self._paths['collection'] = url
+#         self._element_cls = element_cls
+#         super().__init__(client)
+#
+#     def get(self, id):
+#         return self._element_cls(id=id, client=self._client)
+#
+#     def all(self):
+#         return self._client.get(
+#             self._client.get_full_url(
+#                 self.get_path('collection')
+#             )
+#         )
+#
+#     def create(self, **kwargs):
+#         self._client.post(
+#             self._client.get_full_url(
+#                 self.get_path("collection")
+#             ),
+#             json.dumps(payload)
+#         )
+#         return Realm(id=, client=self._client)
+
+class KeycloakAdminEntity(KeycloakAdminBase):
+    _paths = {}
+
+    def __init__(self, client, url):
+        super().__init__(client)
+        self._BASE = url
+        self._paths['formatted'] = self._BASE
+        self._client = client
+        self._entity = None
+        self._get()
+
+    def _get(self):
+        self._entity = self._client.get(
+            self._client.get_full_url(
+                self.get_path('formatted')
+            )
+        )
+
+    @property
+    def entity(self):
+        return self._entity
+
+    def update(self, **kwargs):
+        """
+        Updates the given entity
+        Note: If the url identifier is changed by this method, url won't be changed
+
+        :param kwargs: Entity parameters
+        :return: Response
+        """
+        resp = self._client.put(
+            url=self._client.get_full_url(
+                self.get_path("formatted")
+            ),
+            data=json.dumps(kwargs, sort_keys=True)
+        )
+        self._get()
+        return resp
+
+    def delete(self):
+        """
+        Deleted given entity
+
+        :return: Response
+        """
+        return self._client.delete(
+            self._client.get_full_url(
+                self.get_path("formatted")
+            )
+        )
+
+    def __getattr__(self, item):
+        return self._entity[item]
 
 
 class KeycloakAdmin(object):

--- a/src/keycloak/admin/clients.py
+++ b/src/keycloak/admin/clients.py
@@ -85,9 +85,3 @@ class Client(KeycloakAdminEntity):
                 self.get_path('secret', realm=self._realm_name, id=self._id)
             )
         )
-
-    @property
-    def client(self):
-        if self._info is None:
-            self.get()
-        return self._info

--- a/src/keycloak/admin/clients.py
+++ b/src/keycloak/admin/clients.py
@@ -48,10 +48,11 @@ class Clients(KeycloakAdminBase):
 class Client(KeycloakAdminEntity):
     _id = None
     _realm_name = None
-    _BASE = '/auth/admin/realms/{realm}/clients/{id}/'
+    _BASE = '/auth/admin/realms/{realm}/clients/{id}'
     _paths = {
         'single': _BASE,
-        'service_account': _BASE + 'service-account-user'
+        'service_account': _BASE + '/service-account-user',
+        'secret': _BASE + '/client-secret'
     }
 
     def __init__(self, realm_name, id, client):
@@ -76,6 +77,14 @@ class Client(KeycloakAdminEntity):
             )
         )
         return User(user_id=user["id"], realm_name=self._realm_name, client=self._client)
+
+    @property
+    def secret(self):
+        return self._client.get(
+            self._client.get_full_url(
+                self.get_path('secret', realm=self._realm_name, id=self._id)
+            )
+        )
 
     @property
     def client(self):

--- a/src/keycloak/admin/realm.py
+++ b/src/keycloak/admin/realm.py
@@ -1,20 +1,52 @@
-from keycloak.admin import KeycloakAdminBase
+import json
+
+from keycloak.admin import KeycloakAdminBase, KeycloakAdminEntity
 
 __all__ = ('Realm', 'Realms',)
 
 
 class Realms(KeycloakAdminBase):
+    _paths = {
+        'collection': '/auth/admin/realms'
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(Realms, self).__init__(*args, **kwargs)
 
     def by_name(self, name):
         return Realm(name=name, client=self._client)
 
+    def all(self):
+        return self._client.get(
+            self._client.get_full_url(
+                self.get_path('collection')
+            )
+        )
 
-class Realm(KeycloakAdminBase):
+    def create(self, name, **kwargs):
+        payload = {
+            "realm": name,
+            **kwargs
+        }
+        self._client.post(
+            self._client.get_full_url(
+                self.get_path("collection")
+            ),
+            json.dumps(payload)
+        )
+        return Realm(name=name, client=self._client)
+
+
+class Realm(KeycloakAdminEntity):
     _name = None
+    _paths = {
+        'single': '/auth/admin/realms/{realm}'
+    }
 
-    def __init__(self, name, *args, **kwargs):
+    def __init__(self, name, client):
         self._name = name
-        super(Realm, self).__init__(*args, **kwargs)
+        super(Realm, self).__init__(url=self.get_path("single", realm=name),
+                                    client=client)
 
     @property
     def clients(self):
@@ -30,3 +62,4 @@ class Realm(KeycloakAdminBase):
     def groups(self):
         from keycloak.admin.groups import Groups
         return Groups(realm_name=self._name, client=self._client)
+

--- a/src/keycloak/admin/user/userroles.py
+++ b/src/keycloak/admin/user/userroles.py
@@ -20,6 +20,14 @@ class UserRoleMappings(KeycloakAdminBase):
             client=self._client
         )
 
+    def client(self, client):
+        return UserRoleMappingsClient(
+            realm_name=self._realm_name,
+            user_id=self._user_id,
+            client_id=client._id,
+            client=self._client
+        )
+
 
 class UserRoleMappingsRealm(KeycloakAdminBase):
     _paths = {
@@ -73,6 +81,64 @@ class UserRoleMappingsRealm(KeycloakAdminBase):
             url=self._client.get_full_url(
                 self.get_path(
                     'single', realm=self._realm_name, id=self._user_id
+                )
+            ),
+            data=json.dumps(roles, sort_keys=True)
+        )
+
+
+class UserRoleMappingsClient(KeycloakAdminBase):
+    _BASE = '/auth/admin/realms/{realm}/users/{id}/role-mappings/clients/{client_id}'
+    _paths = {
+        'available': _BASE + '/available',
+        'single': _BASE
+    }
+
+    def __init__(self, realm_name, user_id, client_id, *args, **kwargs):
+        self._realm_name = realm_name
+        self._user_id = user_id
+        self._client_id = client_id
+        super(UserRoleMappingsClient, self).__init__(*args, **kwargs)
+
+    def available(self):
+        return self._client.get(
+            url=self._client.get_full_url(
+                self.get_path(
+                    'available', realm=self._realm_name, id=self._user_id, client_id=self._client_id
+                )
+            )
+        )
+
+    def add(self, roles):
+        """
+        :param roles: _rolerepresentation array keycloak api
+        """
+        return self._client.post(
+            url=self._client.get_full_url(
+                self.get_path(
+                    'single', realm=self._realm_name, id=self._user_id, client_id=self._client_id
+                )
+            ),
+            data=json.dumps(roles, sort_keys=True)
+        )
+
+    def get(self):
+        return self._client.get(
+            url=self._client.get_full_url(
+                self.get_path(
+                    'single', realm=self._realm_name, id=self._user_id, client_id=self._client_id
+                )
+            )
+        )
+
+    def delete(self, roles):
+        """
+        :param roles: _rolerepresentation array keycloak api
+        """
+        return self._client.delete(
+            url=self._client.get_full_url(
+                self.get_path(
+                    'single', realm=self._realm_name, id=self._user_id, client_id=self._client_id
                 )
             ),
             data=json.dumps(roles, sort_keys=True)

--- a/src/keycloak/admin/users.py
+++ b/src/keycloak/admin/users.py
@@ -108,6 +108,10 @@ class User(KeycloakAdminEntity):
                           user_id=self._user_id,
                           client=self._client)
 
+    def update(self, **kwargs):
+        data = {**kwargs, "id": self._user_id}
+        return super().update(**data)
+
     def reset_password(self, password, temporary=False):
         payload = {
             "type": "password",

--- a/src/keycloak/admin/users.py
+++ b/src/keycloak/admin/users.py
@@ -50,12 +50,19 @@ class Users(KeycloakAdminBase):
             if key in kwargs:
                 payload[to_camel_case(key)] = kwargs[key]
 
-        return self._client.post(
+        self._client.post(
             url=self._client.get_full_url(
                 self.get_path('collection', realm=self._realm_name)
             ),
             data=json.dumps(payload, sort_keys=True)
         )
+        users = self._client.get(
+            url=self._client.get_full_url(
+                self.get_path('collection', realm=self._realm_name)
+            ),
+            username=username
+        )
+        return User(realm_name=self._realm_name, user_id=users[0]["id"], client=self._client)
 
     def all(self):
         """

--- a/tests/keycloak/admin/test_client_roles.py
+++ b/tests/keycloak/admin/test_client_roles.py
@@ -52,14 +52,11 @@ class KeycloakAdminClientRolesTestCase(TestCase):
             name='my-role-name',
             description='my-description',
             id='my-id',
-            client_role='my-client-role',
+            clientRole='my-client-role',
             composite=False,
             composites='my-composites',
-            container_id='my-container-id',
-            scope_param_required=True
-        )
-        self.realm.client.get_full_url.assert_called_once_with(
-            '/auth/admin/realms/realm-name/clients/#123/roles/role-name'
+            containerId='my-container-id',
+            scopeParamRequired=True
         )
         self.realm.client.put.assert_called_once_with(
             url=self.realm.client.get_full_url.return_value,

--- a/tests/keycloak/admin/test_users.py
+++ b/tests/keycloak/admin/test_users.py
@@ -22,9 +22,6 @@ class KeycloakAdminUsersTestCase(TestCase):
             email='my-email',
             enabled=True
         )
-        self.realm.client.get_full_url.assert_called_once_with(
-            '/auth/admin/realms/realm-name/users'
-        )
         self.realm.client.post.assert_called_once_with(
             url=self.realm.client.get_full_url.return_value,
             data='{'

--- a/tests/keycloak/admin/test_users.py
+++ b/tests/keycloak/admin/test_users.py
@@ -72,10 +72,9 @@ class KeycloakAdminUsersTestCase(TestCase):
         )
 
     def test_get_single_user(self):
-        self.admin.realms.by_name('realm-name').users.by_id('an-id')
-        self.realm.client.get_full_url.assert_called_once_with(
-            '/auth/admin/realms/realm-name/users/an-id'
-        )
+        user = self.admin.realms.by_name('realm-name').users.by_id('an-id')
+        assert not self.realm.client.get.called
+        user.id
         self.realm.client.get.assert_called_once_with(
             url=self.realm.client.get_full_url.return_value,
             headers={
@@ -89,8 +88,8 @@ class KeycloakAdminUsersTestCase(TestCase):
         user = self.admin.realms.by_name('realm-name').users.by_id("user-id")
         user.update(
             credentials=[{'some': 'value'}],
-            first_name='my-first-name',
-            last_name='my-last-name',
+            firstName='my-first-name',
+            lastName='my-last-name',
             email='my-email',
             enabled=True
         )

--- a/tests/keycloak/admin/test_users.py
+++ b/tests/keycloak/admin/test_users.py
@@ -72,7 +72,7 @@ class KeycloakAdminUsersTestCase(TestCase):
         )
 
     def test_get_single_user(self):
-        self.admin.realms.by_name('realm-name').users.by_id('an-id').user
+        self.admin.realms.by_name('realm-name').users.by_id('an-id')
         self.realm.client.get_full_url.assert_called_once_with(
             '/auth/admin/realms/realm-name/users/an-id'
         )

--- a/tests/keycloak/test_openid_connect.py
+++ b/tests/keycloak/test_openid_connect.py
@@ -115,7 +115,7 @@ class KeycloakOpenidConnectTestCase(TestCase):
                 'scope': 'scope another-scope'
             }
         )
-        self.assertEqual(response, self.realm.client.post.return_value)
+        self.assertEqual(response.token, self.realm.client.post.return_value)
 
     def test_refresh_token(self):
         response = self.openid_client.refresh_token(

--- a/tests/keycloak/test_openid_connect.py
+++ b/tests/keycloak/test_openid_connect.py
@@ -86,7 +86,7 @@ class KeycloakOpenidConnectTestCase(TestCase):
         )
 
     def test_authorization_code(self):
-        response = self.openid_client.authorization_code(
+        token = self.openid_client.authorization_code(
             code='some-code',
             redirect_uri='https://redirect-uri'
         )
@@ -100,7 +100,7 @@ class KeycloakOpenidConnectTestCase(TestCase):
                 'redirect_uri': 'https://redirect-uri'
             }
         )
-        self.assertEqual(response, self.realm.client.post.return_value)
+        self.assertEqual(token.token, self.realm.client.post.return_value)
 
     def test_client_credentials(self):
         response = self.openid_client.client_credentials(


### PR DESCRIPTION
# Overview
- Extracted basic CRUD logic from entities into common superclass `KeycloakAdminEntity`.
  - Entity parameters are available directly (e.g `entity.id`, `entity.serviceAccountsEnabled`).
  - Entity is fetched lazily when needed.
  - Update request shouldn't change unique identifiers, that will make the object not work anymore.
  - Update method doesn't transform snail_case into camelCase.
- Added more methods to `ClientRoles`, `Realms` and  `Clients` collections.
- Added Token class which represents refreshable Token.
  - Token is now returned by most method in `KeycloakOpenIDConnect` class.
  - Token is automatically refreshed when set up as authentication header.
    - **NOTE:** I am not sure about validity of refreshing code for authentication by client_id and client_secret
- Added Pipfile for easier setup
- Edit test to reflect these changes.
 - Removed some `called_only_once` checks because they didn't make sense anymore.

**NOTE:** I noticed that you support python 2.7 (at least it seemed from the code), I am not sure if that would still work after this PR.

