### PR TITLE
Added the option to logout RHSSO user

### DIFF
--- a/src/keycloak/admin/users.py
+++ b/src/keycloak/admin/users.py
@@ -78,7 +78,8 @@ class User(KeycloakAdminBase):
     _BASE = "/auth/admin/realms/{realm}/users/{user_id}"
     _paths = {
         'single': _BASE,
-        'reset_password': _BASE + "/reset-password"
+        'reset_password': _BASE + "/reset-password",
+        'logout': _BASE + "/logout"
     }
 
     def __init__(self, realm_name, user_id, *args, **kwargs):
@@ -182,5 +183,18 @@ class User(KeycloakAdminBase):
                 )
             ),
             data=json.dumps(payload, sort_keys=True)
+        )
+        return result
+
+    def logout(self):
+        """Logs out user with the given user id"""
+        result = self._client.post(
+            url=self._client.get_full_url(
+                self.get_path(
+                    'logout', realm=self._realm_name,
+                    user_id=self._user_id
+                )
+            ),
+            data=None
         )
         return result

--- a/tests/keycloak/admin/test_users.py
+++ b/tests/keycloak/admin/test_users.py
@@ -164,3 +164,19 @@ class KeycloakAdminUsersTestCase(TestCase):
                 'Content-Type': 'application/json'
             }
         )
+
+    @mock.patch('keycloak.admin.users.User.user', {"id": "user-id"})
+    def test_logout_user(self):
+        user = self.admin.realms.by_name('realm-name').users.by_id("user-id")
+        user.logout()
+        self.realm.client.get_full_url.assert_called_with(
+            '/auth/admin/realms/realm-name/users/user-id/logout'
+        )
+        self.realm.client.post.assert_called_once_with(
+            url=self.realm.client.get_full_url.return_value,
+            data=None,
+            headers={
+                'Authorization': 'Bearer some-token',
+                'Content-Type': 'application/json'
+            }
+        )


### PR DESCRIPTION
Adds the logout method to the class User(KeycloakAdminBase).
This methods calls the POST /{realm}/users/{id}/logout keycloak endpoint and logs the user with the given id out.
