### PR TITLE
Reverse order of Mapping imports

### DIFF
--- a/src/keycloak/well_known.py
+++ b/src/keycloak/well_known.py
@@ -1,7 +1,7 @@
 try:
-    from collections import Mapping
-except ImportError:
     from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 
 class KeycloakWellKnown(Mapping):


### PR DESCRIPTION
Currently  `from collections import Mapping` causes the following warning (with Python 3.3 and up):
> DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working.

The proposed change reverses the order of attempted imports and starts with `from collections.abc import Mapping` first.