### PR TITLE
KeycloakClient raised ClientConnectionError 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.4-dev
+current_version = 0.2.5-dev
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-VERSION = '0.2.4-dev'
+VERSION = '0.2.5-dev'
 AIO_COMPATIBLE = sys.version_info >= (3, 5, 3)
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:

--- a/src/keycloak/aio/client.py
+++ b/src/keycloak/aio/client.py
@@ -47,10 +47,11 @@ class KeycloakClient(AsyncInit, SyncKeycloakClient):
         :return:
         """
         async with req_ctx as response:
+            text = await response.text(errors='replace')
+
             try:
                 response.raise_for_status()
             except aiohttp.client.ClientResponseError as cre:
-                text = await response.text(errors='replace')
                 self.logger.debug('{cre}; '
                                   'Request info: {cre.request_info}; '
                                   'Response headers: {cre.headers}; '


### PR DESCRIPTION
If you are trying to read response after raise_for_status with not 200 code, it raises ConnectionError. 
There is an aiohttp issue describes this: https://github.com/aio-libs/aiohttp/issues/3248 