### PR TITLE
Fix authz token handling for Keycloak 12

### DIFF
--- a/src/keycloak/authz.py
+++ b/src/keycloak/authz.py
@@ -63,7 +63,7 @@ class KeycloakAuthz(WellKnownMixin, object):
         missing_padding = len(token) % 4
         if missing_padding != 0:
             token += '=' * (4 - missing_padding)
-        return json.loads(base64.b64decode(token + "===").decode('utf-8'))
+        return json.loads(base64.urlsafe_b64decode(token + "===").decode('utf-8'))
 
     def get_permissions(self, token, resource_scopes_tuples=None,
                         submit_request=False, ticket=None):

--- a/src/keycloak/authz.py
+++ b/src/keycloak/authz.py
@@ -115,7 +115,7 @@ class KeycloakAuthz(WellKnownMixin, object):
                     response.get('error_description')
                 )
             else:
-                token = response.get('refresh_token')
+                token = response.get('access_token')
                 decoded_token = self._decode_token(token.split('.')[1])
                 authz_info = decoded_token.get('authorization', {})
         except KeycloakClientError as error:

--- a/src/keycloak/authz.py
+++ b/src/keycloak/authz.py
@@ -63,7 +63,7 @@ class KeycloakAuthz(WellKnownMixin, object):
         missing_padding = len(token) % 4
         if missing_padding != 0:
             token += '=' * (4 - missing_padding)
-        return json.loads(base64.b64decode(token).decode('utf-8'))
+        return json.loads(base64.b64decode(token + "===").decode('utf-8'))
 
     def get_permissions(self, token, resource_scopes_tuples=None,
                         submit_request=False, ticket=None):


### PR DESCRIPTION
Original code throws an error as such on Keycloak 12:
```
  File "/usr/local/lib/python3.8/site-packages/keycloak/authz.py", line 119, in get_permissions
    decoded_token = self._decode_token(token.split('.')[1])
AttributeError: 'NoneType' object has no attribute 'split'
```

Seems the required data is now in the `access_token` attribute.